### PR TITLE
Fixed 'Invalid form authenticity token' error 

### DIFF
--- a/app/views/decision_trees/_answers.html.erb
+++ b/app/views/decision_trees/_answers.html.erb
@@ -1,4 +1,4 @@
 <% @answers.each do |text, progress, answer| %>
-  <p><%= link_to text, '#', data: { progress: progress, answer: answer } %></p>
+  <p><%= submit_tag text, data: { progress: progress, answer: answer }, onclick: 'handleClickOnAnswer(this)' %></p>
 <% end %>
 

--- a/assets/javascripts/decision_tree.js
+++ b/assets/javascripts/decision_tree.js
@@ -35,15 +35,13 @@ $(document).on('click', 'button.decision-tree', function(e){
   e.preventDefault();
 });
 
-$(document).on('click', '#decision-tree-answers a', function(e){
-  var a = $(this);
+function handleClickOnAnswer(elem) {
+  var input = $(elem);
 
-  console.log(a.data('progress'));
-  console.log(a.data('answer'));
+  console.log(input.data('progress'));
+  console.log(input.data('answer'));
 
-  $('#progress').val(a.data('progress'));
-  $('#answer').val(a.data('answer'));
-  $('#decision-tree-form').submit();
-  hideModal(this);
-  return false;
-});
+  $('#progress').val(input.data('progress'));
+  $('#answer').val(input.data('answer'));
+  hideModal(elem);
+}

--- a/assets/stylesheets/decision_tree.css
+++ b/assets/stylesheets/decision_tree.css
@@ -9,3 +9,16 @@
   margin-bottom: 5px;
 }
 
+#decision-tree-answers input {
+  border: none;
+  background-color: transparent;
+  color: #2996cc;
+  padding: 0px;
+  margin: 0px;
+  height: 16px;
+  line-height: 16px;
+}
+
+#decision-tree-answers input:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed `Invalid form authenticity token` error by switching `<a> + form.submit()` to `<input type='submit'>` with link like styling
- I referred the following Japanese articles.
  - [rails 5でajax送信をするform_tagの設定ではまった話 - Qiita](https://qiita.com/fumi-m/items/f318664e25ee5eb00000)
  - [HTML formのsubmitﾎﾞﾀﾝをLINK風に表示する方法 | ものづくりとプログラミング日記](http://miha.jugem.cc/?eid=151)
- I confirmed that all tests passed.

@gtt-project/maintainer
